### PR TITLE
 Simplify smoke test examples resource consumption 

### DIFF
--- a/example_hello.py
+++ b/example_hello.py
@@ -11,7 +11,7 @@ from jobs import ImageOptions, JobOptions, ResourceOptions, SchedulingOptions, j
             name="localhost:5000/hello-world-dev",
             tag="latest",
         ),
-        resources=ResourceOptions(memory="4Gi", cpu="2"),
+        resources=ResourceOptions(memory="1Gi", cpu="1"),
         scheduling=SchedulingOptions(
             priority_class="background", queue_name="user-queue"
         ),

--- a/example_mnist_tf.py
+++ b/example_mnist_tf.py
@@ -8,9 +8,9 @@ USE_GPU = False
 @job(
     options=JobOptions(
         image=ImageOptions(
-            spec=Path("example-docker.yaml"), name="mlops:5000/tf-example"
+            spec=Path("example-docker.yaml"), name="localhost:5000/tf-example"
         ),
-        resources=ResourceOptions(memory="4Gi", cpu="2", gpu=1 if USE_GPU else None),
+        resources=ResourceOptions(memory="1Gi", cpu="2", gpu=1 if USE_GPU else None),
     )
 )
 def mnist_train() -> None:


### PR DESCRIPTION
such that it puts less strain on developer machines.
Also change the namespace from 'mlops' back to 'localhost' to
avoid manual namespace setup in a new cluster instance upon testing.

If more resources or a custom namespace is required, we can set it up
quickly when needed. Otherwise, for the default, this setup will be
more convenient.