### PR TITLE
Improve formatting of status CLI output

### DIFF
--- a/client/src/cli/commands/status.py
+++ b/client/src/cli/commands/status.py
@@ -1,9 +1,9 @@
 import argparse
 from argparse import ArgumentParser
-from pprint import pp
 from typing import Any
 
 import openapi_client
+from jobq.utils.helpers import format_dict
 
 from .util import with_job_mgmt_api
 
@@ -11,7 +11,7 @@ from .util import with_job_mgmt_api
 @with_job_mgmt_api
 def status(client: openapi_client.JobManagementApi, args: argparse.Namespace) -> None:
     resp = client.status_jobs_uid_status_get(uid=args.uid)
-    pp(resp)
+    print(format_dict(resp.to_dict()))
 
 
 def add_parser(subparsers: Any, parent: ArgumentParser) -> None:

--- a/client/src/jobq/utils/helpers.py
+++ b/client/src/jobq/utils/helpers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+import textwrap
 from collections.abc import Mapping
 from typing import Any, TypeVar, cast
 
@@ -10,3 +12,78 @@ def remove_none_values(d: T) -> T:
     """Remove all keys with a ``None`` value from a dict."""
     filtered_dict = {k: v for k, v in d.items() if v is not None}
     return cast(T, filtered_dict)
+
+
+def snake_to_human(s: str) -> str:
+    """Convert a snake_case string to a human-readable string."""
+    return s.replace("_", " ")
+
+
+def camel_to_human(s: str) -> str:
+    """Convert a camelCase string to a human-readable string.
+
+    Examples
+    --------
+    >>> camel_to_human("camelCase")
+    'Camel Case'
+    >>> camel_to_human("camelCaseString")
+    'Camel Case String'
+    >>> camel_to_human("randomID")
+    'Random ID'
+    """
+    # Use regex to find positions where a lowercase letter is followed by an uppercase letter
+    s = re.sub("([a-z])([A-Z])", r"\1 \2", s)
+
+    # Capitalize the first letter of each word
+    return s
+
+
+def to_human(s: str) -> str:
+    """Convert a string to a human-readable string."""
+    result = s
+    if s.islower():
+        result = snake_to_human(s)
+    else:
+        result = camel_to_human(s)
+    return result.title()
+
+
+def format_dict(d: Mapping[str, Any], level: int = 0, indent_width: int = 2) -> str:
+    """Format a dict in a human-readable format.
+
+    Simple values are printed as-is, lists are printed as comma-separated values,
+    and dicts are recursively formatted with keys as section headers.
+    """
+
+    def format_value(value: Any, level: int) -> str:
+        if isinstance(value, Mapping):
+            return format_dict(value, level + 1)
+        elif isinstance(value, list):
+            return "\n".join(
+                " " * ((level + 1) * indent_width)
+                + "- "
+                + format_value(item, level + 1).strip()
+                for item in value
+            )
+        else:
+            strval = str(value).strip()
+            if "\n" in strval:
+                return "\n" + textwrap.indent(
+                    strval, prefix=" " * (level * indent_width)
+                )
+            else:
+                return strval
+
+    indent = " " * (level * indent_width)
+    formatted_items = []
+
+    for key, value in d.items():
+        formatted_value = format_value(value, level) or f"{indent}    <empty>"
+        header = f"{indent}{to_human(key)}"
+
+        if isinstance(value, list | Mapping):
+            formatted_items.append(f"{header}:\n{formatted_value}\n")
+        else:
+            formatted_items.append(f"{header}: {formatted_value}")
+
+    return "\n".join(formatted_items)


### PR DESCRIPTION
This PR improves the readability of the `jobq status` command output.

It recursively turns nested objects into indented blocks and attempts to turn snake-case or camel-case identifiers into human-readable form (i.e., space separated, title cased).

### Example

```console
$ jobq status 8cb95872-3c2a-47f6-b847-6112ece94ad8    
Managed Resource Id: 8cb95872-3c2a-47f6-b847-6112ece94ad8
Execution Status: JobStatus.SUCCEEDED
Spec:
  Pod Sets:
    - Count: 1
      Name: main
      Template:
        Metadata:
            <empty>

        Spec:
          Containers:
            - Command:
                - jobs_execute
                - examples/example_hello.py
                - hello_world

              Image: localhost:5000/hello-world-dev:latest
              Image Pull Policy: IfNotPresent
              Name: workload
              Resources:
                Limits:
                  Cpu: 1
                  Memory: 1Gi

                Requests:
                  Cpu: 1
                  Memory: 1Gi


              Termination Message Path: /dev/termination-log
              Termination Message Policy: File

          Dns Policy: ClusterFirst
          Restart Policy: Never
          Scheduler Name: default-scheduler
          Security Context:
              <empty>

          Termination Grace Period Seconds: 30

  Queue Name: user-queue
  Active: True
  Priority Class Name: background
  Priority: 1
  Priority Class Source: kueue.x-k8s.io/workloadpriorityclass

Kueue Status:
  Conditions:
    - Last Transition Time: 2024-09-20T06:55:41Z
      Message: Quota reserved in ClusterQueue cluster-queue
      Observed Generation: 1
      Reason: QuotaReserved
      Status: True
      Type: QuotaReserved
    - Last Transition Time: 2024-09-20T06:55:41Z
      Message: The workload is admitted
      Observed Generation: 1
      Reason: Admitted
      Status: True
      Type: Admitted
    - Last Transition Time: 2024-09-20T06:56:05Z
      Message: Reached expected number of succeeded pods
      Observed Generation: 1
      Reason: Succeeded
      Status: True
      Type: Finished

  Admission:
    Cluster Queue: cluster-queue
    Pod Set Assignments:
      - Count: 1
        Flavors:
          Cpu: default-flavor
          Memory: default-flavor

        Name: main
        Resource Usage:
          Cpu: 1
          Memory: 1Gi


  Requeue State: None
  Reclaimable Pods: None
  Admission Checks: None

Submission Timestamp: 2024-09-20 06:55:41+00:00
Last Admission Timestamp: 2024-09-20 06:55:41+00:00
Termination Timestamp: 2024-09-20 06:56:05+00:00
Was Evicted: False
Was Inadmissible: False
Has Failed Pods: False
```