### PR TITLE
Separate client CLI dependencies into `jobq[cli]` extra

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,4 +24,4 @@ FROM python:${PYTHON_VERSION}
 WORKDIR /code
 COPY --from=build /code /code
 
-CMD ["/code/.venv/bin/fastapi", "run", "src/jobq_server/__main__.py", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["/code/.venv/bin/uvicorn", "jobq_server.__main__:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -17,13 +17,17 @@ maintainers = [
     { name = "Adrian Rumpold", email = "a.rumpold@appliedai-institute.de" },
 ]
 dependencies = [
-    "fastapi[standard]",
+    "fastapi",
+    "uvicorn",
+    "docker",
     "kubernetes",
-    "jobq @ git+https://github.com/aai-institute/jobq.git@main#subdirectory=client",
+    # FIXME: Move back to `main` after merging PR
+    "jobq @ git+https://github.com/aai-institute/jobq.git@173fc0f225251f9c593536e40af303d8d88b14fb#subdirectory=client",
 ]
 
 [project.optional-dependencies]
 dev = [
+    "fastapi[standard]",
     "build",
     "ruff",
     "pytest",

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -33,7 +33,7 @@ dnspython==2.6.1
     # via email-validator
 docker==7.1.0
     # via
-    #   jobq
+    #   jobq-server (pyproject.toml)
     #   testcontainers
 email-validator==2.2.0
     # via fastapi
@@ -55,8 +55,6 @@ httptools==0.6.1
     # via uvicorn
 httpx==0.27.0
     # via fastapi
-humanize==4.10.0
-    # via jobq
 identify==2.6.0
     # via pre-commit
 idna==3.7
@@ -69,7 +67,7 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.4
     # via fastapi
-jobq @ git+https://github.com/aai-institute/jobq.git@90c8a7b6dee1da29bf2098314e855a716d5974ab#subdirectory=client
+jobq @ git+https://github.com/aai-institute/jobq.git@173fc0f225251f9c593536e40af303d8d88b14fb#subdirectory=client
     # via jobq-server (pyproject.toml)
 kubernetes==30.1.0
     # via jobq-server (pyproject.toml)
@@ -121,9 +119,7 @@ pytest-cov==5.0.0
 pytest-mock==3.14.0
     # via jobq-server (pyproject.toml)
 python-dateutil==2.9.0.post0
-    # via
-    #   jobq
-    #   kubernetes
+    # via kubernetes
 python-dotenv==1.0.1
     # via uvicorn
 python-multipart==0.0.9
@@ -142,9 +138,7 @@ requests==2.32.3
 requests-oauthlib==2.0.0
     # via kubernetes
 rich==13.7.1
-    # via
-    #   jobq
-    #   typer
+    # via typer
 rsa==4.9
     # via google-auth
 ruff==0.5.6
@@ -180,6 +174,7 @@ urllib3==2.2.2
     #   testcontainers
 uvicorn==0.30.5
     # via
+    #   jobq-server (pyproject.toml)
     #   fastapi
     #   fastapi-cli
 uvloop==0.19.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,66 +3,33 @@
 annotated-types==0.7.0
     # via pydantic
 anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
+    # via starlette
 cachetools==5.4.0
     # via google-auth
 certifi==2024.7.4
     # via
-    #   httpcore
-    #   httpx
     #   kubernetes
     #   requests
 charset-normalizer==3.3.2
     # via requests
 click==8.1.7
-    # via
-    #   typer
-    #   uvicorn
-dnspython==2.6.1
-    # via email-validator
+    # via uvicorn
 docker==7.1.0
-    # via jobq
-email-validator==2.2.0
-    # via fastapi
+    # via jobq-server (pyproject.toml)
 fastapi==0.112.0
     # via jobq-server (pyproject.toml)
-fastapi-cli==0.0.5
-    # via fastapi
 google-auth==2.33.0
     # via kubernetes
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-humanize==4.10.0
-    # via jobq
 idna==3.7
     # via
     #   anyio
-    #   email-validator
-    #   httpx
     #   requests
-jinja2==3.1.4
-    # via fastapi
-jobq @ git+https://github.com/aai-institute/jobq.git@90c8a7b6dee1da29bf2098314e855a716d5974ab#subdirectory=client
+jobq @ git+https://github.com/aai-institute/jobq.git@173fc0f225251f9c593536e40af303d8d88b14fb#subdirectory=client
     # via jobq-server (pyproject.toml)
 kubernetes==30.1.0
     # via jobq-server (pyproject.toml)
-markdown-it-py==3.0.0
-    # via rich
-markupsafe==2.1.5
-    # via jinja2
-mdurl==0.1.2
-    # via markdown-it-py
 oauthlib==3.2.2
     # via
     #   kubernetes
@@ -79,21 +46,12 @@ pydantic==2.8.2
     #   jobq
 pydantic-core==2.20.1
     # via pydantic
-pygments==2.18.0
-    # via rich
 python-dateutil==2.9.0.post0
-    # via
-    #   jobq
-    #   kubernetes
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
+    # via kubernetes
 pyyaml==6.0.2
     # via
     #   jobq
     #   kubernetes
-    #   uvicorn
 requests==2.32.3
     # via
     #   docker
@@ -101,46 +59,27 @@ requests==2.32.3
     #   requests-oauthlib
 requests-oauthlib==2.0.0
     # via kubernetes
-rich==13.7.1
-    # via
-    #   jobq
-    #   typer
 rsa==4.9
     # via google-auth
-shellingham==1.5.4
-    # via typer
 six==1.16.0
     # via
     #   kubernetes
     #   python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 starlette==0.37.2
     # via fastapi
-typer==0.12.3
-    # via fastapi-cli
 typing-extensions==4.12.2
     # via
     #   fastapi
     #   pydantic
     #   pydantic-core
-    #   typer
 urllib3==2.2.2
     # via
     #   docker
     #   kubernetes
     #   requests
-uvicorn==0.30.5
-    # via
-    #   fastapi
-    #   fastapi-cli
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.23.0
-    # via uvicorn
+uvicorn==0.30.6
+    # via jobq-server (pyproject.toml)
 websocket-client==1.8.0
     # via kubernetes
-websockets==12.0
-    # via uvicorn

--- a/client/pyproject.toml
+++ b/client/pyproject.toml
@@ -8,16 +8,7 @@ description = ""
 version = "0.1.0"
 readme = "README.md"
 requires-python = ">=3.10"
-# TODO: Move CLI deps (humanize, rich) to an extra so that SDK users do not have to install them
-dependencies = [
-    "docker",
-    "humanize",
-    "pydantic",
-    "pydantic-settings",
-    "python-dateutil",
-    "pyyaml",
-    "rich",
-]
+dependencies = ["pydantic", "pyyaml"]
 authors = [
     { name = "appliedAI Institute for Europe", email = "opensource@appliedai-institute.de" },
 ]
@@ -32,6 +23,7 @@ jobs_execute = "jobs.execute:execute"
 jobq = "cli:main"
 
 [project.optional-dependencies]
+cli = ["docker", "humanize", "rich", "pydantic-settings", "python-dateutil"]
 dev = [
     "build",
     "ruff",

--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -2,49 +2,15 @@
 #    uv pip compile --strip-extras -o requirements.txt pyproject.toml
 annotated-types==0.7.0
     # via pydantic
-certifi==2024.8.30
-    # via requests
-charset-normalizer==3.3.2
-    # via requests
-docker==7.1.0
-    # via jobq (pyproject.toml)
-humanize==4.10.0
-    # via jobq (pyproject.toml)
-idna==3.8
-    # via requests
-markdown-it-py==3.0.0
-    # via rich
-mdurl==0.1.2
-    # via markdown-it-py
 pydantic==2.9.0
-    # via
-    #   jobq (pyproject.toml)
-    #   pydantic-settings
+    # via jobq (pyproject.toml)
 pydantic-core==2.23.2
     # via pydantic
-pydantic-settings==2.5.2
-    # via jobq (pyproject.toml)
-pygments==2.18.0
-    # via rich
-python-dateutil==2.9.0.post0
-    # via jobq (pyproject.toml)
-python-dotenv==1.0.1
-    # via pydantic-settings
 pyyaml==6.0.2
     # via jobq (pyproject.toml)
-requests==2.32.3
-    # via docker
-rich==13.8.0
-    # via jobq (pyproject.toml)
-six==1.16.0
-    # via python-dateutil
 typing-extensions==4.12.2
     # via
     #   pydantic
     #   pydantic-core
 tzdata==2024.1
     # via pydantic
-urllib3==2.2.2
-    # via
-    #   docker
-    #   requests


### PR DESCRIPTION
This PR restructures the dependencies of the client package into a core and additional CLI dependencies.

This allows the backend to reduce its transitive dependencies, which are further avoided by installing `fastapi` without the `fastapi[standard]` extra (cutting container image size from 214 to 187 MiB).