### PR TITLE
Add install instruction, micro synopsis to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,14 @@ jobq logs 4c0d4cbb-13a2-4d05-afde-8784e22bb940
 ```
 
 jobq is an early stage project, so expect rough edges. We are happy for feedback and may accomodate your feature requests, so don't hesitate to get in touch.
+
+## Contributions
+
+If you'd like to contribute to jobq, the best way to do so is to open an [issue](https://github.com/aai-institute/jobq/issues) for bug reports and feature requests,
+or start a [discussion](https://github.com/aai-institute/jobq/discussions) for topics around the project, and features that might need prior feedback from the core developers.
+
+For more information on how to contribute, refer to the contribution guide. (TODO: Link contribution guide once merged.)
+
+## License
+
+jobq is distributed under the Apache-2 license (TODO: Add link to license).

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ jobq is an early stage project, so expect rough edges. We are happy for feedback
 If you'd like to contribute to jobq, the best way to do so is to open an [issue](https://github.com/aai-institute/jobq/issues) for bug reports and feature requests,
 or start a [discussion](https://github.com/aai-institute/jobq/discussions) for topics around the project, and features that might need prior feedback from the core developers.
 
-For more information on how to contribute, refer to the contribution guide. (TODO: Link contribution guide once merged.)
+For more information on how to contribute, refer to the [contribution guide](CONTRIBUTING.md).
 
 ## License
 
-jobq is distributed under the Apache-2 license (TODO: Add link to license).
+jobq is distributed under the [Apache-2 license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
-# Jobq: Multi-backend Job definition and Management from Python and the CLI
+# jobq: Packaging, scheduling, and monitoring Python workloads as k8s jobs
 
-Jobq is a compute job definition, workflow management and scheduling tool that supports Kubernetes, Kueue, and Ray backends.
+jobq is a tool to define, schedule, and observe compute jobs as Python functions in Kubernetes.
+It supports Docker (standard Kubernetes), Kueue, and Ray backends for workload execution.
+
+The `jobq` Python package itself is split into a client and backend part.
+The client package is used to define jobs with the `@job` decorator in your Python files, and (optionally) to interact with an existing API server through a CLI.
+The backend contains a FastAPI-based server application that acts as an intermediary between the user and the target Kubernetes cluster, and can be easily packaged into a Docker container or a virtual machine for deployment.
+
+## Installation
+
+Depending on what your role is, you will likely require only some parts of the `jobq` package.
+
+As a data scientist, you only require the client part to define and dispatch jobs.
+To install the client package, simply use `pip`:
+
+```shell
+pip install --upgrade "aai-jobq[cli]"
+```
+
+This instruction includes the command-line interface to interact with an existing Kubernetes cluster.
+If that functionality is not needed, simply omit the bracketed extra from the install command.
+If you need to deploy the backend as well, you will need to install the `jobq-server` package:
+
+```shell
+pip install --upgrade aai-jobq-server
+```
 
 Define jobs in your `.py` files by using the `@job` decorator on the function that contains your compute logic.
 Within the decorator you define the desired resources and link the environment configuration. We support Dockerfiles or a declarative `.yaml` file specification.


### PR DESCRIPTION
Currently non-functional, until the final PyPI names have been decided.

Emphasizes the split between the two packages, and mentions which user persona likely needs which package.


---------------------

Still missing:

* Links to contribution guides, mentions of the license, and so on.
* Badges (if we want them).

And the same discussion as before applies: What goes into the readme? Do we give an example? Do we link to the quickstart guide? Do we use special media (screen recording of the CLI, job defs, etc.)?

Happy for inputs.