### PR TITLE
[deps] Add aai-jobq to backend dependencies as a source

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
                     --install-types,
                 ]
     - repo: https://github.com/astral-sh/uv-pre-commit
-      rev: 0.4.18
+      rev: 0.4.19
       hooks:
           - id: uv-lock
             name: Lock project dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.6.0
+      rev: v5.0.0
       hooks:
           - id: check-added-large-files
           - id: check-json
@@ -11,7 +11,7 @@ repos:
           - id: end-of-file-fixer
           - id: mixed-line-ending
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.6.3
+      rev: v0.6.9
       hooks:
           - id: ruff
             args: [--fix]
@@ -30,3 +30,8 @@ repos:
                     --non-interactive,
                     --install-types,
                 ]
+    - repo: https://github.com/astral-sh/uv-pre-commit
+      rev: 0.4.18
+      hooks:
+          - id: uv-lock
+            name: Lock project dependencies

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ Selective package upgrade for existing dependencies are also handled by the help
 If you want to update the Pydantic dependency, for example, simply run:
 
 ```console
-uv add pydantic
+uv add -P pydantic
 ```
 
 > [!IMPORTANT]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,19 +148,19 @@ If you have to update a dependency during development, you should do the followi
 2. In case of a development dependency, add it to the `dev` section of the `project.optional-dependencies` table instead.
 3. Dependencies needed for documentation generation are found in the `docs` sections of `project.optional-dependencies`.
 
-After adding the dependency in either of these sections, run the helper script `hack/lock-deps.sh` (which in turn uses `uv pip compile`) to pin all dependencies again:
+After adding the dependency in either of these sections, lock all dependencies again:
 
 ```console
-hack/lock-deps.sh
+uv lock
 ```
 
-In addition to these manual steps, we also provide `pre-commit` hooks that automatically lock the dependencies whenever `pyproject.toml` is changed.
+In addition to these manual steps, we also provide a `pre-commit` hook that automatically locks the dependencies whenever `pyproject.toml` is changed.
 
 Selective package upgrade for existing dependencies are also handled by the helper script above.
 If you want to update the Pydantic dependency, for example, simply run:
 
 ```console
-hack/lock-deps.sh pydantic
+uv add pydantic
 ```
 
 > [!IMPORTANT]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,8 +21,7 @@ dependencies = [
     "uvicorn",
     "docker",
     "kubernetes",
-    # FIXME: Revert to main branch once PR is merged
-    "aai-jobq @ git+https://github.com/aai-institute/jobq.git@28b535e905e9b7dd4195c928ed02bbf186235f91#subdirectory=client",
+    "aai-jobq",
 ]
 dynamic = ["version"]
 
@@ -63,3 +62,6 @@ exclude_also = ["@overload", "raise NotImplementedError", "if TYPE_CHECKING:"]
 markers = [
     "e2e: mark a test as an end-to-end test (requires Kubernetes tooling)",
 ]
+
+[tool.uv.sources]
+aai-jobq = { git = "https://github.com/aai-institute/jobq", branch = "main", subdirectory = "client" }

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -7,8 +7,8 @@ resolution-markers = [
 
 [[package]]
 name = "aai-jobq"
-version = "0.1.0"
-source = { git = "https://github.com/aai-institute/jobq.git?subdirectory=client&rev=28b535e905e9b7dd4195c928ed02bbf186235f91#28b535e905e9b7dd4195c928ed02bbf186235f91" }
+version = "0.1.0rc4.dev74+g28c0261"
+source = { git = "https://github.com/aai-institute/jobq?subdirectory=client&branch=main#28c0261faa3d50423c8cae1bcf6e2ac6a7edcd3a" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -16,7 +16,7 @@ dependencies = [
 
 [[package]]
 name = "aai-jobq-server"
-version = "0.1.0rc8.dev8+g0c3e7ca.d20241002"
+version = "0.1.0rc8.dev11+g28c0261.d20241007"
 source = { editable = "." }
 dependencies = [
     { name = "aai-jobq" },
@@ -40,7 +40,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aai-jobq", git = "https://github.com/aai-institute/jobq.git?subdirectory=client&rev=28b535e905e9b7dd4195c928ed02bbf186235f91#28b535e905e9b7dd4195c928ed02bbf186235f91" },
+    { name = "aai-jobq", git = "https://github.com/aai-institute/jobq?subdirectory=client&branch=main" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "docker" },
     { name = "fastapi" },


### PR DESCRIPTION
This allows us to use aai-jobq directly from `main`, or from the currently checked out commit. I currently use `main`, which may not be enough in cases where we require commits from a feature branch, e.g. due to client regeneration.

Also adds `uv lock` as a pre-commit hook (albeit only for the docs right now, I guess).