### PR TITLE
Correctly install regular pip dependencies in declarative image builds

### DIFF
--- a/client/tests/smoke/_data/docker.yaml
+++ b/client/tests/smoke/_data/docker.yaml
@@ -1,25 +1,25 @@
 build:
-  base_image: python:3.12-slim
-  dependencies:
-    apt: [curl, git]
-    pip: [attrs, pyyaml]
-  volumes:
-    - .:.
-  user: 
-    name: no_admin
-  config:
-    env:
-      - var: secret
-    arg:
-      - build_arg: config
-    stopsignal: 1
-    shell: sh
-  meta:
-    labels: 
-      - test: test
-  workdir: /usr/src/
-  filesystem:
-    copy:
-      - . : .
-    add:
-      - . : .
+    base_image: python:3.12-slim
+    dependencies:
+        apt: [curl, git]
+        pip: [attrs, pyyaml, test.whl, marker-package, -e.]
+    volumes:
+        - .:.
+    user:
+        name: no_admin
+    config:
+        env:
+            - var: secret
+        arg:
+            - build_arg: config
+        stopsignal: 1
+        shell: sh
+    meta:
+        labels:
+            - test: test
+    workdir: /usr/src/
+    filesystem:
+        copy:
+            - .: .
+        add:
+            - .: .

--- a/client/tests/smoke/test_build_from_yaml.py
+++ b/client/tests/smoke/test_build_from_yaml.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 from jobq import assembler
@@ -18,7 +19,29 @@ def test_build_image_from_yaml():
             tag="test",
         ),
     )
-    testjob._render_dockerfile()
+    dockerfile = testjob._render_dockerfile()
+
+    # Base image
+    pattern = r"FROM python:3.12-slim"
+    assert (
+        re.search(pattern, dockerfile) is not None
+    ), "Base image not found or incorrect"
+
+    # Wheel installation
+    pattern = r"RUN .* pip install.*test\.whl"
+    assert re.search(pattern, dockerfile) is not None, "Wheel installation not found"
+
+    # Editable package install
+    pattern = r"RUN .* pip install.*-e[ ]?[.]"
+    assert (
+        re.search(pattern, dockerfile) is not None
+    ), "Editable package installation not found"
+
+    # Regular package install
+    pattern = r"RUN .* pip install.*marker-package"
+    assert (
+        re.search(pattern, dockerfile) is not None
+    ), "Marker package installation not found"
 
 
 def test_image_assembler():


### PR DESCRIPTION
PR description courtese of Copilot, let's try this thing out 😄

---

This pull request includes several changes to the `client/src/jobq/assembler/renderers.py` file to improve the handling of package dependencies and their installation in Docker images. It also updates the test suite to ensure these changes are correctly validated. The most important changes include copying the `pip` list to avoid modifying the original, removing processed packages from the list, and adding new assertions in the test cases to verify the Dockerfile content.

Improvements to dependency handling:

* [`client/src/jobq/assembler/renderers.py`](diffhunk://#diff-9923dc8fff66f328eb0b11970ba1a2b01526754aa8d74789eda68b8b3f5ead57L99-R100): Copied the `pip` list to avoid modifying the original list directly.
* [`client/src/jobq/assembler/renderers.py`](diffhunk://#diff-9923dc8fff66f328eb0b11970ba1a2b01526754aa8d74789eda68b8b3f5ead57R118-R146): Removed processed packages (wheels, requirements, build folders, and editable installs) from the `pip` list to ensure only the remaining packages are installed at the end. [[1]](diffhunk://#diff-9923dc8fff66f328eb0b11970ba1a2b01526754aa8d74789eda68b8b3f5ead57R118-R146) [[2]](diffhunk://#diff-9923dc8fff66f328eb0b11970ba1a2b01526754aa8d74789eda68b8b3f5ead57R159-R162)

Updates to test cases:

* [`client/tests/smoke/_data/docker.yaml`](diffhunk://#diff-6d8679aff419ff45b9ac6cd47fb75828e9258ed62f2e45bfa9e0a80f627b5b3fL5-R5): Added new dependencies to the `pip` list in the Docker configuration for testing purposes.
* [`client/tests/smoke/test_build_from_yaml.py`](diffhunk://#diff-717b9280805cb46e04d5efba5ce60feb0d0749c339f8e7b86f364dd5d023e6e5R1): Added assertions to check the presence of the base image, wheel installation, editable package install, and regular package install in the rendered Dockerfile. [[1]](diffhunk://#diff-717b9280805cb46e04d5efba5ce60feb0d0749c339f8e7b86f364dd5d023e6e5R1) [[2]](diffhunk://#diff-717b9280805cb46e04d5efba5ce60feb0d0749c339f8e7b86f364dd5d023e6e5L21-R44)